### PR TITLE
Add DiscordWebhookDisabledEvents option

### DIFF
--- a/HeadlessTweaks/DiscordIntegration.cs
+++ b/HeadlessTweaks/DiscordIntegration.cs
@@ -99,16 +99,19 @@ namespace HeadlessTweaks
         {
             public static void WorldCreated(World world)
             {
+                if (HeadlessTweaks.config.GetValue(HeadlessTweaks.DiscordWebhookDisabledEvents)?.Contains("WorldStarted") ?? false) return;
                 DiscordHelper.SendWorldEmbed(world, "Started", new Color(r: 0.0f, g: 0.8f, b: 0.8f));
                 return;
             }
             public static void WorldSaved(World world)
             {
+                if (HeadlessTweaks.config.GetValue(HeadlessTweaks.DiscordWebhookDisabledEvents)?.Contains("WorldSaved") ?? false) return;
                 DiscordHelper.SendWorldEmbed(world, "Saved", new Color(r: 0.8f, g: 0.8f, b: 0.0f));
                 return;
             }
             public static void WorldDestroyed(World world)
             {
+                if (HeadlessTweaks.config.GetValue(HeadlessTweaks.DiscordWebhookDisabledEvents)?.Contains("WorldClosing") ?? false) return;
                 DiscordHelper.SendWorldEmbed(world, "Closing", new Color(r: 0.8f, g: 0.2f, b: 0.0f));
                 return;
             }
@@ -119,19 +122,22 @@ namespace HeadlessTweaks
                     WorldCreated(user.World);
                     if (user.HeadDevice == HeadOutputDevice.Headless) return;
                 }
+                if (HeadlessTweaks.config.GetValue(HeadlessTweaks.DiscordWebhookDisabledEvents)?.Contains("UserJoined") ?? false) return;
                 DiscordHelper.SendUserEmbed(user, "Joined", new Color(r: 0.0f, g: 0.8f, b: 0.0f));
             }
             public static void UserLeft(User user)
             {
+                if (HeadlessTweaks.config.GetValue(HeadlessTweaks.DiscordWebhookDisabledEvents)?.Contains("UserLeft") ?? false) return;
                 DiscordHelper.SendUserEmbed(user, "Left", new Color(r: 0.8f, g: 0.0f, b: 0.0f));
             }
             public static void HeadlessStartup()
             {
+                if (HeadlessTweaks.config.GetValue(HeadlessTweaks.DiscordWebhookDisabledEvents)?.Contains("HeadlessStarted") ?? false) return;
                 DiscordHelper.SendStartEmbed(Engine.Current, "Headless [{1}] started with version {0}", new Color(r: 0.0f, g: 0.0f, b: 1.0f));
             }
             public static void HeadlessShutdown()
             {
-
+                if (HeadlessTweaks.config.GetValue(HeadlessTweaks.DiscordWebhookDisabledEvents)?.Contains("HeadlessShutdown") ?? false) return;
                 DiscordHelper.SendStartEmbed(Engine.Current, "Shutting down Headless [{1}]", new Color(r: 1.0f, g: 0.0f, b: 0.0f));
             }
         }

--- a/HeadlessTweaks/HeadlessTweaks.cs
+++ b/HeadlessTweaks/HeadlessTweaks.cs
@@ -10,7 +10,7 @@ namespace HeadlessTweaks
     {
         public override string Name => "HeadlessTweaks";
         public override string Author => "New-Project-Final-Final-WIP";
-        public override string Version => "1.2.0";
+        public override string Version => "1.3.0";
         public override string Link => "https://github.com/New-Project-Final-Final-WIP/HeadlessTweaks";
 
         public static bool isHeadless;
@@ -28,6 +28,8 @@ namespace HeadlessTweaks
         public static readonly ModConfigurationKey<string> DiscordWebhookUsername = new ModConfigurationKey<string>("DiscordWebhookUsername", "Discord Webhook Username", () => null);
         [AutoRegisterConfigKey]
         public static readonly ModConfigurationKey<string> DiscordWebhookAvatar = new ModConfigurationKey<string>("DiscordWebhookAvatar", "Discord Webhook Avatar", () => null);
+        [AutoRegisterConfigKey]
+        public static readonly ModConfigurationKey<List<string>> DiscordWebhookDisabledEvents = new ModConfigurationKey<List<string>>("DiscordWebhookDisabledEvents", "Discord Webhook Events without notification", () => new List<string>());
         
         [AutoRegisterConfigKey]
         public static readonly ModConfigurationKey<List<string>> AutoInviteOptOut = new ModConfigurationKey<List<string>>("AutoInviteOptOut", "Auto Invite Opt Out", () => new List<string>(), internalAccessOnly: true);

--- a/README.md
+++ b/README.md
@@ -46,6 +46,18 @@ You can set `UseDiscordWebhook` to `true` in your config to enable these feature
 - `DiscordWebhookKey` - Webhook Key taken from a Discord channel WebHook integration URL (`https://discord.com/api/webhooks/WEBHOOK_ID_HERE/WEBHOOK_KEY_HERE`)
 - `DiscordWebhookUsername` - Display name that will be attached to messages sent by this integration
 - `DiscordWebhookAvatar` - HTTP or NEOSDB URL to Avatar/PFP image that will be attached to messages sent by this integration
+- `DiscordWebhookDisabledEvents` - A list of event names you don't want Discord to log. The list of all event names is below.
+    ```json
+    "DiscordWebhookDisabledEvents": [
+        "HeadlessStarted",
+        "HeadlessShutdown",
+        "WorldStarted",
+        "WorldSaved",
+        "WorldClosing",
+        "UserJoined",
+        "UserLeft"
+    ],
+    ```
 
 ### Auto Invitation Opt-Out
 It's useful to auto-invite users when a headless spins up. However this can get kind of spammy. Users can opt-out of auto-invites with the `/optOut` chat command or by have their name manually entered in the `AutoInviteOptOut` list. The list simply takes user IDs. For example:


### PR DESCRIPTION
Discord integration can now specify which events it does not want logged to Discord.